### PR TITLE
Feat: 소셜 로그인 기눙 추가

### DIFF
--- a/src/main/java/com/walkingtalking/gunilda/user/dto/SocialSignDTO.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/dto/SocialSignDTO.java
@@ -1,0 +1,27 @@
+package com.walkingtalking.gunilda.user.dto;
+
+import com.walkingtalking.gunilda.user.type.SocialType;
+import lombok.Builder;
+
+public class SocialSignDTO {
+
+    @Builder
+    public record SignInRequest(String type, String id) {
+        public SignInCommand toCommand() {
+            return SignInCommand.builder()
+                    .socialType(SocialType.find(type))
+                    .id(id)
+                    .build();
+        }
+    }
+
+    @Builder
+    public record SignInCommand(SocialType socialType, String id) {
+
+    }
+
+    @Builder
+    public record SignInResponse(Long userId) {
+
+    }
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/dto/UserSignDTO.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/dto/UserSignDTO.java
@@ -1,0 +1,57 @@
+package com.walkingtalking.gunilda.user.dto;
+
+import lombok.Builder;
+
+public class UserSignDTO {
+
+    @Builder
+    public record SignUpRequest(String sid, String pw) {
+        public SignUpCommand toCommand() {
+            return SignUpCommand.builder()
+                    .sid(sid)
+                    .pwHash(pw) //나중에 반드시 hash로 변환하는 로직 넣을 것 TO-DO
+                    .build();
+        }
+    }
+
+    @Builder
+    public record SignUpCommand(String sid, String pwHash) {
+
+    }
+
+    @Builder
+    public record SignUpResponse(Long userId) {
+
+    }
+
+    @Builder
+    public record SignInRequest() {
+
+    }
+
+    @Builder
+    public record SignInCommand() {
+
+    }
+
+    @Builder
+    public record SignInResponse() {
+
+    }
+
+    @Builder
+    public record SignOutRequest() {
+
+    }
+
+    @Builder
+    public record SignOutCommand() {
+
+    }
+
+    @Builder
+    public record SignOutResponse() {
+
+    }
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/entity/Social.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/entity/Social.java
@@ -1,0 +1,36 @@
+package com.walkingtalking.gunilda.user.entity;
+
+import com.walkingtalking.gunilda.user.type.SocialType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Social {
+
+    @Id
+    private Long index;
+
+    @Column(nullable = false)
+    private SocialType socialType;
+
+    @Column(nullable = false)
+    private String socialId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    public static Social of(SocialType socialType, String socialId, Long userId) {
+        return Social.builder()
+                .socialType(socialType)
+                .socialId(socialId)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/entity/User.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/entity/User.java
@@ -3,10 +3,18 @@ package com.walkingtalking.gunilda.user.entity;
 import com.walkingtalking.gunilda.user.type.AgeType;
 import com.walkingtalking.gunilda.user.type.GenderType;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
 
 @Entity
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "Users")
 public class User {
 
@@ -14,10 +22,26 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
+    @Column(nullable = false)
     private AgeType age;
 
+    @Column(nullable = false)
     private GenderType gender;
 
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private String nickname;
+
+    private String sid;
+
+    private String pwHash;
+
+    public static User of(String sid, String pwHash) {
+        return User.builder()
+                .gender(GenderType.UNKNOWN)
+                .age(AgeType.UNKNOWN)
+                .nickname(UUID.randomUUID().toString())
+                .sid(sid)
+                .pwHash(pwHash)
+                .build();
+    }
 }

--- a/src/main/java/com/walkingtalking/gunilda/user/repository/SocialRepository.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/repository/SocialRepository.java
@@ -1,0 +1,12 @@
+package com.walkingtalking.gunilda.user.repository;
+
+import com.walkingtalking.gunilda.user.entity.Social;
+import com.walkingtalking.gunilda.user.type.SocialType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SocialRepository extends JpaRepository<Social, Long> {
+
+    boolean existsBySocialTypeAndSocialId(SocialType socialType, String socialId);
+    Social findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/service/SocialSignService.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/SocialSignService.java
@@ -1,0 +1,9 @@
+package com.walkingtalking.gunilda.user.service;
+
+import com.walkingtalking.gunilda.user.dto.SocialSignDTO;
+
+public interface SocialSignService {
+
+    SocialSignDTO.SignInResponse signin(SocialSignDTO.SignInCommand signInCommand);
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/service/SocialSignService.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/SocialSignService.java
@@ -4,6 +4,6 @@ import com.walkingtalking.gunilda.user.dto.SocialSignDTO;
 
 public interface SocialSignService {
 
-    SocialSignDTO.SignInResponse signin(SocialSignDTO.SignInCommand signInCommand);
+    SocialSignDTO.SignInResponse signIn(SocialSignDTO.SignInCommand signInCommand);
 
 }

--- a/src/main/java/com/walkingtalking/gunilda/user/service/UserSignService.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/UserSignService.java
@@ -1,0 +1,11 @@
+package com.walkingtalking.gunilda.user.service;
+
+import com.walkingtalking.gunilda.user.dto.UserSignDTO;
+
+public interface UserSignService {
+
+    UserSignDTO.SignUpResponse signup(UserSignDTO.SignUpCommand signUpCommand);
+    UserSignDTO.SignInResponse signin(UserSignDTO.SignInCommand signInCommand);
+    UserSignDTO.SignOutResponse signout(UserSignDTO.SignOutCommand signOutCommand);
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/service/UserSignService.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/UserSignService.java
@@ -4,8 +4,8 @@ import com.walkingtalking.gunilda.user.dto.UserSignDTO;
 
 public interface UserSignService {
 
-    UserSignDTO.SignUpResponse signup(UserSignDTO.SignUpCommand signUpCommand);
-    UserSignDTO.SignInResponse signin(UserSignDTO.SignInCommand signInCommand);
-    UserSignDTO.SignOutResponse signout(UserSignDTO.SignOutCommand signOutCommand);
+    UserSignDTO.SignUpResponse signUp(UserSignDTO.SignUpCommand signUpCommand);
+    UserSignDTO.SignInResponse signIn(UserSignDTO.SignInCommand signInCommand);
+    UserSignDTO.SignOutResponse signOut(UserSignDTO.SignOutCommand signOutCommand);
 
 }

--- a/src/main/java/com/walkingtalking/gunilda/user/service/impl/SocialSignServiceImpl.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/impl/SocialSignServiceImpl.java
@@ -21,7 +21,7 @@ public class SocialSignServiceImpl implements SocialSignService {
 
     @Override
     @Transactional
-    public SocialSignDTO.SignInResponse signin(SocialSignDTO.SignInCommand signInCommand) {
+    public SocialSignDTO.SignInResponse signIn(SocialSignDTO.SignInCommand signInCommand) {
         if (!socialRepository.existsBySocialTypeAndSocialId(signInCommand.socialType(), signInCommand.id())) {
             //등록되지 않은 소셜 정보라면 새로운 사용자를 생성함
             //소셜 로그인 시 아이디, 비밀번호 내용은 필요 없으므로 랜덤 값을 저장함
@@ -30,7 +30,7 @@ public class SocialSignServiceImpl implements SocialSignService {
                     .pw(UUID.randomUUID().toString())
                     .build();
 
-            UserSignDTO.SignUpResponse userSignUpResponse = userSignService.signup(userSignUpRequest.toCommand());
+            UserSignDTO.SignUpResponse userSignUpResponse = userSignService.signUp(userSignUpRequest.toCommand());
 
             //새로운 사용자를 바탕으로 소셜과 연동함
             Social social = Social.of(signInCommand.socialType(), signInCommand.id(), userSignUpResponse.userId());

--- a/src/main/java/com/walkingtalking/gunilda/user/service/impl/SocialSignServiceImpl.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/impl/SocialSignServiceImpl.java
@@ -1,0 +1,49 @@
+package com.walkingtalking.gunilda.user.service.impl;
+
+import com.walkingtalking.gunilda.user.dto.SocialSignDTO;
+import com.walkingtalking.gunilda.user.dto.UserSignDTO;
+import com.walkingtalking.gunilda.user.entity.Social;
+import com.walkingtalking.gunilda.user.repository.SocialRepository;
+import com.walkingtalking.gunilda.user.service.SocialSignService;
+import com.walkingtalking.gunilda.user.service.UserSignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SocialSignServiceImpl implements SocialSignService {
+
+    private final SocialRepository socialRepository;
+    private final UserSignService userSignService;
+
+    @Override
+    @Transactional
+    public SocialSignDTO.SignInResponse signin(SocialSignDTO.SignInCommand signInCommand) {
+        if (!socialRepository.existsBySocialTypeAndSocialId(signInCommand.socialType(), signInCommand.id())) {
+            //등록되지 않은 소셜 정보라면 새로운 사용자를 생성함
+            //소셜 로그인 시 아이디, 비밀번호 내용은 필요 없으므로 랜덤 값을 저장함
+            UserSignDTO.SignUpRequest userSignUpRequest = UserSignDTO.SignUpRequest.builder()
+                    .sid(UUID.randomUUID().toString())
+                    .pw(UUID.randomUUID().toString())
+                    .build();
+
+            UserSignDTO.SignUpResponse userSignUpResponse = userSignService.signup(userSignUpRequest.toCommand());
+
+            //새로운 사용자를 바탕으로 소셜과 연동함
+            Social social = Social.of(signInCommand.socialType(), signInCommand.id(), userSignUpResponse.userId());
+            socialRepository.save(social);
+        }
+
+        Social social = socialRepository.findBySocialTypeAndSocialId(signInCommand.socialType(), signInCommand.id());
+
+        return SocialSignDTO.SignInResponse.builder()
+                .userId(social.getUserId())
+                .build();
+    }
+
+    //회원탈퇴 시 Listener를 이용해서 소셜 정보도 같이 삭제되게 구현해야 함
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/service/impl/UserSignServiceImpl.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/impl/UserSignServiceImpl.java
@@ -16,7 +16,7 @@ public class UserSignServiceImpl implements UserSignService {
 
     @Override
     @Transactional
-    public UserSignDTO.SignUpResponse signup(UserSignDTO.SignUpCommand signUpCommand) {
+    public UserSignDTO.SignUpResponse signUp(UserSignDTO.SignUpCommand signUpCommand) {
         //나중에 아이디, 비밀번호로 회원가입을 할 경우 아이디 예외 처리를 여기에 구현할 것
 
         User user = User.of(signUpCommand.sid(), signUpCommand.pwHash());
@@ -36,14 +36,14 @@ public class UserSignServiceImpl implements UserSignService {
     //나중에 아이디, 비밀번호로 로그인하게 될 경우 아래 함수를 구현할 것
     @Override
     @Transactional
-    public UserSignDTO.SignInResponse signin(UserSignDTO.SignInCommand signInCommand) {
+    public UserSignDTO.SignInResponse signIn(UserSignDTO.SignInCommand signInCommand) {
         return null;
     }
 
     //나중에 회원탈퇴를 만들게 될 경우 아래 함수를 구현할 것
     @Override
     @Transactional
-    public UserSignDTO.SignOutResponse signout(UserSignDTO.SignOutCommand signOutCommand) {
+    public UserSignDTO.SignOutResponse signOut(UserSignDTO.SignOutCommand signOutCommand) {
         return null;
     }
 }

--- a/src/main/java/com/walkingtalking/gunilda/user/service/impl/UserSignServiceImpl.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/impl/UserSignServiceImpl.java
@@ -1,0 +1,49 @@
+package com.walkingtalking.gunilda.user.service.impl;
+
+import com.walkingtalking.gunilda.user.dto.UserSignDTO;
+import com.walkingtalking.gunilda.user.entity.User;
+import com.walkingtalking.gunilda.user.repository.UserRepository;
+import com.walkingtalking.gunilda.user.service.UserSignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserSignServiceImpl implements UserSignService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public UserSignDTO.SignUpResponse signup(UserSignDTO.SignUpCommand signUpCommand) {
+        //나중에 아이디, 비밀번호로 회원가입을 할 경우 아이디 예외 처리를 여기에 구현할 것
+
+        User user = User.of(signUpCommand.sid(), signUpCommand.pwHash());
+
+        userRepository.save(user);
+
+        //유저의 기본 닉네임을 guest + 서비스 ID로 설정함
+        user.setNickname("guest" + user.getUserId());
+
+        userRepository.save(user);
+
+        return UserSignDTO.SignUpResponse.builder()
+                .userId(user.getUserId())
+                .build();
+    }
+
+    //나중에 아이디, 비밀번호로 로그인하게 될 경우 아래 함수를 구현할 것
+    @Override
+    @Transactional
+    public UserSignDTO.SignInResponse signin(UserSignDTO.SignInCommand signInCommand) {
+        return null;
+    }
+
+    //나중에 회원탈퇴를 만들게 될 경우 아래 함수를 구현할 것
+    @Override
+    @Transactional
+    public UserSignDTO.SignOutResponse signout(UserSignDTO.SignOutCommand signOutCommand) {
+        return null;
+    }
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/type/SocialType.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/type/SocialType.java
@@ -1,0 +1,32 @@
+package com.walkingtalking.gunilda.user.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@AllArgsConstructor
+@Getter
+public enum SocialType {
+    UNKNOWN("unknown"),
+    KAKAO("kakao"),
+    GOOGLE("google"),
+    APPLE("apple");
+
+    private final String social;
+
+    private static final Map<String, SocialType> socials =
+            Collections.unmodifiableMap(
+                    Stream.of(SocialType.values())
+                    .collect(Collectors.toMap(SocialType::getSocial, Function.identity()))
+            );
+
+    public static SocialType find(String social) {
+        return Optional.ofNullable(socials.get(social)).orElse(UNKNOWN);
+    }
+}


### PR DESCRIPTION
### 변경점
- 추후 확장성을 위해 id, password를 사용해 회원가입, 로그인하는 로직 추가
- 소셜 로그인 시 회원가입이 되어 있지 않으면 자동으로 회원가입이 되도록 하는 기능 추가
- 소셜 로그인 후 로그인 된 사용자 ID를 반환해 줌

### 해야할 점
- 사용자 ID를 담는 JWT 토큰을 발급해 줘야 함