### PR TITLE
fix: Social 테이블의 id가 자동으로 주입되지 않던 버그 수정

### DIFF
--- a/src/main/java/com/walkingtalking/gunilda/user/entity/Social.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/entity/Social.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 public class Social {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long index;
 
     @Column(nullable = false)


### PR DESCRIPTION
### 변경점
- Social 엔티티의 Id인 index에 @GeneratedValue 어노테이션 추가