### PR TITLE
Feat: JWT 토큰 발급 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/resources/jwt.properties
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/walkingtalking/gunilda/auth/configuration/RedisConfig.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/configuration/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.walkingtalking.gunilda.auth.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private Integer port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/controller/AuthController.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/controller/AuthController.java
@@ -1,0 +1,39 @@
+package com.walkingtalking.gunilda.auth.controller;
+
+import com.walkingtalking.gunilda.auth.dto.JwtTokenDTO;
+import com.walkingtalking.gunilda.auth.provider.JwtProvider;
+import com.walkingtalking.gunilda.user.dto.SocialSignDTO;
+import com.walkingtalking.gunilda.user.service.SocialSignService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final JwtProvider jwtProvider;
+    private final SocialSignService socialSignService;
+
+    @PostMapping("/login")
+    public ResponseEntity<JwtTokenDTO.GeneratingResponse> socialLogin(@RequestBody SocialSignDTO.SignInRequest request) {
+        SocialSignDTO.SignInResponse signInResponse = socialSignService.signIn(request.toCommand());
+
+        JwtTokenDTO.GeneratingWithIdRequest jwtRequest = JwtTokenDTO.GeneratingWithIdRequest.builder()
+                .userId(signInResponse.userId())
+                .build();
+
+        return ResponseEntity.ok(jwtProvider.generateToken(jwtRequest));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<JwtTokenDTO.GeneratingResponse> refresh(@RequestBody JwtTokenDTO.GeneratingWithRefreshTokenRequest request) {
+        return ResponseEntity.ok(jwtProvider.generateToken(request));
+    }
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/dto/JwtTokenDTO.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/dto/JwtTokenDTO.java
@@ -1,0 +1,31 @@
+package com.walkingtalking.gunilda.auth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.util.Date;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class JwtTokenDTO {
+
+    @Builder
+    public record GeneratingWithIdRequest(Long userId) {
+
+    }
+
+    @Builder
+    public record GeneratingWithRefreshTokenRequest(String refreshToken) {
+
+    }
+
+    @Builder
+    public record GeneratingResponse(String accessToken, String refreshToken) {
+
+    }
+
+    @Builder
+    public record TokenPayload(Long userId, Date issuedAt, Date expiration) {
+
+    }
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/dto/JwtTokenDTO.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/dto/JwtTokenDTO.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 
 import java.util.Date;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class JwtTokenDTO {
 
     @Builder
@@ -15,11 +14,13 @@ public class JwtTokenDTO {
     }
 
     @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record GeneratingWithRefreshTokenRequest(String refreshToken) {
 
     }
 
     @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record GeneratingResponse(String accessToken, String refreshToken) {
 
     }

--- a/src/main/java/com/walkingtalking/gunilda/auth/entity/AccessTokenBlackList.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/entity/AccessTokenBlackList.java
@@ -1,0 +1,26 @@
+package com.walkingtalking.gunilda.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.concurrent.TimeUnit;
+
+@Data
+@RedisHash
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AccessTokenBlackList {
+
+    @Id
+    private String accessToken;
+
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long ttl;
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/entity/AccessTokenBlackList.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/entity/AccessTokenBlackList.java
@@ -8,8 +8,6 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
-import java.util.concurrent.TimeUnit;
-
 @Data
 @RedisHash
 @NoArgsConstructor
@@ -20,7 +18,7 @@ public class AccessTokenBlackList {
     @Id
     private String accessToken;
 
-    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    @TimeToLive
     private Long ttl;
 
 }

--- a/src/main/java/com/walkingtalking/gunilda/auth/entity/RefreshToken.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/entity/RefreshToken.java
@@ -9,8 +9,6 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
-import java.util.concurrent.TimeUnit;
-
 @RedisHash
 @Data
 @NoArgsConstructor
@@ -26,7 +24,7 @@ public class RefreshToken {
 
     private String accessToken;
 
-    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    @TimeToLive
     private Long ttl;
 
 }

--- a/src/main/java/com/walkingtalking/gunilda/auth/entity/RefreshToken.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/entity/RefreshToken.java
@@ -1,0 +1,32 @@
+package com.walkingtalking.gunilda.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+import java.util.concurrent.TimeUnit;
+
+@RedisHash
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+    @Id
+    private String refreshToken;
+
+    @Indexed
+    private Long userId;
+
+    private String accessToken;
+
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long ttl;
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/exception/AuthException.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/exception/AuthException.java
@@ -1,0 +1,16 @@
+package com.walkingtalking.gunilda.auth.exception;
+
+import com.walkingtalking.gunilda.base.BaseException;
+import com.walkingtalking.gunilda.base.BaseExceptionType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class AuthException extends BaseException {
+
+    private BaseExceptionType exceptionType;
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/exception/type/AuthExceptionType.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/exception/type/AuthExceptionType.java
@@ -1,0 +1,19 @@
+package com.walkingtalking.gunilda.auth.exception.type;
+
+import com.walkingtalking.gunilda.base.BaseExceptionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthExceptionType implements BaseExceptionType {
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "A000", "Access Token이 만료되었습니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "Refresh Token이 만료되었습니다."),
+    DUPLICATE_SIGN_IN(HttpStatus.UNAUTHORIZED, "A002", "중복 로그인이 감지되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "Token이 손상되었습니다.");
+
+    HttpStatus httpStatus;
+    String errorCode;
+    String message;
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/exception/type/AuthExceptionType.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/exception/type/AuthExceptionType.java
@@ -13,7 +13,7 @@ public enum AuthExceptionType implements BaseExceptionType {
     DUPLICATE_SIGN_IN(HttpStatus.UNAUTHORIZED, "A002", "중복 로그인이 감지되었습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "Token이 손상되었습니다.");
 
-    HttpStatus httpStatus;
-    String errorCode;
-    String message;
+    final HttpStatus httpStatus;
+    final String errorCode;
+    final String message;
 }

--- a/src/main/java/com/walkingtalking/gunilda/auth/provider/JwtProvider.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/provider/JwtProvider.java
@@ -1,0 +1,145 @@
+package com.walkingtalking.gunilda.auth.provider;
+
+import com.walkingtalking.gunilda.auth.dto.JwtTokenDTO;
+import com.walkingtalking.gunilda.auth.entity.AccessTokenBlackList;
+import com.walkingtalking.gunilda.auth.entity.RefreshToken;
+import com.walkingtalking.gunilda.auth.exception.AuthException;
+import com.walkingtalking.gunilda.auth.exception.type.AuthExceptionType;
+import com.walkingtalking.gunilda.auth.repository.AccessTokenBlackListWithRedis;
+import com.walkingtalking.gunilda.auth.repository.RefreshTokenRepositoryWithRedis;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@PropertySource("classpath:jwt.properties")
+public class JwtProvider {
+
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 60 * 1000L; //1시간
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 7 * 24 * 60 * 60 * 1000L; //7일
+
+    private final RefreshTokenRepositoryWithRedis tokenRepository;
+    private final AccessTokenBlackListWithRedis blackListRepository;
+    private SecretKey secretKey;
+    private JwtParser jwtParser;
+
+    @Autowired
+    public JwtProvider(@Value("${jwt.secret_key}") String key,
+                       RefreshTokenRepositoryWithRedis tokenRepository,
+                       AccessTokenBlackListWithRedis blackListRepository) {
+
+        //설정한 key를 base64로 인코딩하고 HMAC-SHA로 암호화한다.
+        this.secretKey = Keys.hmacShaKeyFor(Base64.getEncoder().encodeToString(key.getBytes()).getBytes());
+        this.jwtParser = Jwts.parser().verifyWith(secretKey).build();
+        this.tokenRepository = tokenRepository;
+        this.blackListRepository = blackListRepository;
+    }
+
+    @Transactional
+    public JwtTokenDTO.GeneratingResponse generateToken(JwtTokenDTO.GeneratingWithIdRequest request) {
+        return generateToken(request.userId());
+    }
+
+    @Transactional
+    public JwtTokenDTO.GeneratingResponse generateToken(JwtTokenDTO.GeneratingWithRefreshTokenRequest request) {
+        if (!tokenRepository.existsById(request.refreshToken())) {
+            throw new AuthException(AuthExceptionType.EXPIRED_REFRESH_TOKEN);
+        }
+
+        RefreshToken token = tokenRepository.findById(request.refreshToken()).get();
+
+        return generateToken(token.getUserId());
+    }
+
+    public JwtTokenDTO.TokenPayload verify(String accessToken) {
+        try {
+            Claims claims = jwtParser.parseSignedClaims(accessToken).getPayload();
+
+            return JwtTokenDTO.TokenPayload.builder()
+                    .userId(Long.parseLong(claims.get("userId").toString()))
+                    .issuedAt(claims.getIssuedAt())
+                    .expiration(claims.getExpiration())
+                    .build();
+
+        } catch (ExpiredJwtException eje) {
+            throw new AuthException(AuthExceptionType.EXPIRED_ACCESS_TOKEN);
+        } catch (SignatureException | NumberFormatException e) {
+            throw new AuthException(AuthExceptionType.INVALID_TOKEN);
+        }
+    }
+
+    private JwtTokenDTO.GeneratingResponse generateToken(Long userId) {
+        JwtTokenDTO.GeneratingResponse response = JwtTokenDTO.GeneratingResponse.builder()
+                .accessToken(generateAccessToken(userId))
+                .refreshToken(generateRefreshToken())
+                .build();
+
+        RefreshToken token = RefreshToken.builder()
+                .refreshToken(response.refreshToken())
+                .accessToken(response.accessToken())
+                .userId(userId)
+                .ttl(REFRESH_TOKEN_EXPIRATION_TIME)
+                .build();
+
+        removePreviousToken(userId);
+
+        tokenRepository.save(token);
+
+        return response;
+    }
+
+    private String generateAccessToken(Long userId) {
+        return Jwts.builder()
+                .claim("userId", userId)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION_TIME))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    private String generateRefreshToken() {
+        return Jwts.builder()
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION_TIME))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    private void removePreviousToken(Long userId) {
+        if (!tokenRepository.existsByUserId(userId)) {
+            return;
+        }
+
+        RefreshToken token = tokenRepository.findByUserId(userId).get();
+
+        // 중복 로그인 방지를 위한 코드
+        // refresh token을 명시적으로 삭제한다는 것은 중복 로그인이 되었다는 의미임
+        // 따라서 현재 이용 가능한 access token을 블랙리스트로 만들어 이전에 로그인 했던 사용자의 접근을 차단함
+        try {
+            String accessTokenForBlackList = token.getAccessToken();
+            Long ttl = verify(accessTokenForBlackList).expiration().getTime() - System.currentTimeMillis();
+
+            AccessTokenBlackList blackListToken = AccessTokenBlackList.builder()
+                    .accessToken(accessTokenForBlackList)
+                    .ttl(ttl) //블랙리스트 기간을 토큰 만료 기간과 동일하게 잡음
+                    .build();
+
+            blackListRepository.save(blackListToken);
+        } catch (AuthException ae) {}//access token을 삭제할 필요가 없음.
+
+        tokenRepository.delete(token);
+    }
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/repository/AccessTokenBlackListWithRedis.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/repository/AccessTokenBlackListWithRedis.java
@@ -1,0 +1,9 @@
+package com.walkingtalking.gunilda.auth.repository;
+
+import com.walkingtalking.gunilda.auth.entity.AccessTokenBlackList;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccessTokenBlackListWithRedis extends CrudRepository<AccessTokenBlackList, String> {
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/repository/RefreshTokenRepositoryWithRedis.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/repository/RefreshTokenRepositoryWithRedis.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 @Repository
 public interface RefreshTokenRepositoryWithRedis extends CrudRepository<RefreshToken, String> {
 
-    boolean existsByUserId(Long userId);
     Optional<RefreshToken> findByUserId(Long userId);
 
 }

--- a/src/main/java/com/walkingtalking/gunilda/auth/repository/RefreshTokenRepositoryWithRedis.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/repository/RefreshTokenRepositoryWithRedis.java
@@ -1,0 +1,15 @@
+package com.walkingtalking.gunilda.auth.repository;
+
+import com.walkingtalking.gunilda.auth.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepositoryWithRedis extends CrudRepository<RefreshToken, String> {
+
+    boolean existsByUserId(Long userId);
+    Optional<RefreshToken> findByUserId(Long userId);
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/entity/Social.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/entity/Social.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 public class Social {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long index;
 
     @Column(nullable = false)


### PR DESCRIPTION
### 변경점
- 소셜 type, id를 받았을 때 등록되지 않은 사용자면 자체 회원가입 후 로그인하고, 등록된 사용자면 바로 로그인함
- 로그인 시 서비스 ID를 담은 access token과 재발급을 위한 refresh token을 클라이언트에게 전달함
- refresh token은 한 번 사용 시 새로운 refresh token으로 재발급함 (즉, 다시 사용할 수 없음)
- refresh token 재발급 시 중복 로그인을 방지하기 위해 사용중인 access token을 redis에 저장함으로써 blacklist로 처리함
(access token 만료 시간까지 blacklist 처리)

### 해야할 점
- access token verify 기능은 구현했는데 실제로 사용하는 로직을 구현해야 함
- 그 이후 중복 로그인이 실제로 막히는 지 확인해야 함