### PR TITLE
Feat: JWT 인증 기능 추가

### DIFF
--- a/src/main/java/com/walkingtalking/gunilda/auth/configuration/WebConfig.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/configuration/WebConfig.java
@@ -1,0 +1,25 @@
+package com.walkingtalking.gunilda.auth.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.walkingtalking.gunilda.auth.interceptorr.TokenInterceptor;
+import com.walkingtalking.gunilda.auth.provider.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new TokenInterceptor(jwtProvider, objectMapper))
+                .order(1)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/auth/**");
+    }
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/exception/type/AuthExceptionType.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/exception/type/AuthExceptionType.java
@@ -11,7 +11,8 @@ public enum AuthExceptionType implements BaseExceptionType {
     EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "A000", "Access Token이 만료되었습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "Refresh Token이 만료되었습니다."),
     DUPLICATE_SIGN_IN(HttpStatus.UNAUTHORIZED, "A002", "중복 로그인이 감지되었습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "Token이 손상되었습니다.");
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "Token이 손상되었습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "A004", "Token을 찾을 수 없습니다.");
 
     final HttpStatus httpStatus;
     final String errorCode;

--- a/src/main/java/com/walkingtalking/gunilda/auth/interceptorr/TokenInterceptor.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/interceptorr/TokenInterceptor.java
@@ -1,6 +1,5 @@
 package com.walkingtalking.gunilda.auth.interceptorr;
 
-import ch.qos.logback.classic.encoder.JsonEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.walkingtalking.gunilda.auth.dto.JwtTokenDTO;
 import com.walkingtalking.gunilda.auth.exception.AuthException;

--- a/src/main/java/com/walkingtalking/gunilda/auth/interceptorr/TokenInterceptor.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/interceptorr/TokenInterceptor.java
@@ -1,0 +1,66 @@
+package com.walkingtalking.gunilda.auth.interceptorr;
+
+import ch.qos.logback.classic.encoder.JsonEncoder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.walkingtalking.gunilda.auth.dto.JwtTokenDTO;
+import com.walkingtalking.gunilda.auth.exception.AuthException;
+import com.walkingtalking.gunilda.auth.exception.type.AuthExceptionType;
+import com.walkingtalking.gunilda.auth.provider.JwtProvider;
+import com.walkingtalking.gunilda.base.BaseExceptionDTO;
+import io.jsonwebtoken.lang.Strings;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Enumeration;
+
+@RequiredArgsConstructor
+public class TokenInterceptor implements HandlerInterceptor {
+
+    private static final String AUTHORIZATION = "Authorization";
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String token = extractToken(request, "Bearer");
+
+        try {
+            if (token.isEmpty()) {
+                throw new AuthException(AuthExceptionType.TOKEN_NOT_FOUND);
+            }
+
+            JwtTokenDTO.TokenPayload payload = jwtProvider.verify(token);
+
+            request.setAttribute("userId", payload.userId());
+
+        } catch (AuthException ae) {
+            BaseExceptionDTO exceptionDTO = BaseExceptionDTO.from(ae);
+            String body = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(exceptionDTO);
+
+            response.setStatus(ae.getExceptionType().getHttpStatus().value());
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(body);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private String extractToken(HttpServletRequest request, String type) {
+        Enumeration<String> headers = request.getHeaders(AUTHORIZATION);
+
+        while (headers.hasMoreElements()) {
+            String value = headers.nextElement();
+            if (value.toLowerCase().startsWith(type.toLowerCase())) {
+                return value.substring(type.length()).trim();
+            }
+        }
+
+        return Strings.EMPTY;
+    }
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/auth/provider/JwtProvider.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/provider/JwtProvider.java
@@ -61,6 +61,10 @@ public class JwtProvider {
     }
 
     public JwtTokenDTO.TokenPayload verify(String accessToken) {
+        if (blackListRepository.existsById(accessToken)) {
+            throw new AuthException(AuthExceptionType.DUPLICATE_SIGN_IN);
+        }
+
         try {
             Claims claims = jwtParser.parseSignedClaims(accessToken).getPayload();
 

--- a/src/main/java/com/walkingtalking/gunilda/user/controller/UserProfileController.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/controller/UserProfileController.java
@@ -14,23 +14,20 @@ public class UserProfileController {
     private final UserProfileService profileService;
 
     @PostMapping()
-    public ResponseEntity<UserProfileDTO.CreateProfileResponse> createProfile(@RequestBody UserProfileDTO.CreateProfileRequest profileRequest) {
-        Long userId = 0L; //TO-DO
-
+    public ResponseEntity<UserProfileDTO.CreateProfileResponse> createProfile(@RequestBody UserProfileDTO.CreateProfileRequest profileRequest,
+                                                                              @RequestAttribute Long userId) {
         return ResponseEntity.ok(profileService.createProfile(profileRequest.toCommand(userId)));
     }
 
     @PatchMapping("/profile")
-    public ResponseEntity<UserProfileDTO.ChangeProfileResponse> changeProfile(@RequestBody UserProfileDTO.ChangeProfileRequest profileRequest) {
-        Long userId = 0L; //TO-DO
-
+    public ResponseEntity<UserProfileDTO.ChangeProfileResponse> changeProfile(@RequestBody UserProfileDTO.ChangeProfileRequest profileRequest,
+                                                                              @RequestAttribute Long userId) {
         return ResponseEntity.ok(profileService.changeProfile(profileRequest.toCommand(userId)));
     }
 
     @PatchMapping("/nickname")
-    public ResponseEntity<UserProfileDTO.ChangeNicknameResponse> changeNickname(@RequestBody UserProfileDTO.ChangeNicknameRequest nicknameRequest) {
-        Long userId = 0L; //TO-DL
-
+    public ResponseEntity<UserProfileDTO.ChangeNicknameResponse> changeNickname(@RequestBody UserProfileDTO.ChangeNicknameRequest nicknameRequest,
+                                                                                @RequestAttribute Long userId) {
         return ResponseEntity.ok(profileService.changeNickname(nicknameRequest.toCommand(userId)));
     }
 }


### PR DESCRIPTION
### 변경점
#### [JWT]

- 인증이 필요한 url로 API 요청 시 토큰 인증을 거치는 interceptor 추가함
- 토큰이 없거나 토큰이 만료됐거나 토큰이 손상됐다면 401 status code 반환함
- 정상적으로 검증이 끝난 토큰에서 서비스 ID를 추출해 request attribute에 저장함
<br>

#### [UserProfile]
-  사용자 정보를 변경하는 컨트롤러에서 interceptor에서 저장한 userId를 가져와 사용하도록 로직을 추가함
