### PR TITLE
Fix: login API 명세서와 구현이 달랐던 점 수정

### DIFF
--- a/src/main/java/com/walkingtalking/gunilda/auth/controller/AuthController.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.walkingtalking.gunilda.auth.controller;
 
 import com.walkingtalking.gunilda.auth.dto.JwtTokenDTO;
+import com.walkingtalking.gunilda.auth.dto.SocialLoginResponseDTO;
 import com.walkingtalking.gunilda.auth.provider.JwtProvider;
 import com.walkingtalking.gunilda.user.dto.SocialSignDTO;
 import com.walkingtalking.gunilda.user.service.SocialSignService;
@@ -22,14 +23,22 @@ public class AuthController {
     private final SocialSignService socialSignService;
 
     @PostMapping("/login")
-    public ResponseEntity<JwtTokenDTO.GeneratingResponse> socialLogin(@RequestBody SocialSignDTO.SignInRequest request) {
+    public ResponseEntity<SocialLoginResponseDTO> socialLogin(@RequestBody SocialSignDTO.SignInRequest request) {
         SocialSignDTO.SignInResponse signInResponse = socialSignService.signIn(request.toCommand());
 
         JwtTokenDTO.GeneratingWithIdRequest jwtRequest = JwtTokenDTO.GeneratingWithIdRequest.builder()
                 .userId(signInResponse.userId())
                 .build();
 
-        return ResponseEntity.ok(jwtProvider.generateToken(jwtRequest));
+        JwtTokenDTO.GeneratingResponse jwtResponse = jwtProvider.generateToken(jwtRequest);
+
+        SocialLoginResponseDTO response = SocialLoginResponseDTO.builder()
+                .accessToken(jwtResponse.accessToken())
+                .refreshToken(jwtResponse.refreshToken())
+                .needInitialization(signInResponse.needInitialization())
+                .build();
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/walkingtalking/gunilda/auth/controller/AuthController.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/controller/AuthController.java
@@ -32,13 +32,7 @@ public class AuthController {
 
         JwtTokenDTO.GeneratingResponse jwtResponse = jwtProvider.generateToken(jwtRequest);
 
-        SocialLoginResponseDTO response = SocialLoginResponseDTO.builder()
-                .accessToken(jwtResponse.accessToken())
-                .refreshToken(jwtResponse.refreshToken())
-                .needInitialization(signInResponse.needInitialization())
-                .build();
-
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(SocialLoginResponseDTO.from(jwtResponse, signInResponse));
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/walkingtalking/gunilda/auth/dto/SocialLoginResponseDTO.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/dto/SocialLoginResponseDTO.java
@@ -2,6 +2,7 @@ package com.walkingtalking.gunilda.auth.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.walkingtalking.gunilda.user.dto.SocialSignDTO;
 import lombok.Builder;
 
 
@@ -9,5 +10,12 @@ import lombok.Builder;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record SocialLoginResponseDTO(String accessToken, String refreshToken, Boolean needInitialization) {
 
+    public static SocialLoginResponseDTO from(JwtTokenDTO.GeneratingResponse jwtResponse, SocialSignDTO.SignInResponse signInResponse) {
+        return SocialLoginResponseDTO.builder()
+                .accessToken(jwtResponse.accessToken())
+                .refreshToken(jwtResponse.refreshToken())
+                .needInitialization(signInResponse.needInitialization())
+                .build();
+    }
 
 }

--- a/src/main/java/com/walkingtalking/gunilda/auth/dto/SocialLoginResponseDTO.java
+++ b/src/main/java/com/walkingtalking/gunilda/auth/dto/SocialLoginResponseDTO.java
@@ -1,0 +1,13 @@
+package com.walkingtalking.gunilda.auth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SocialLoginResponseDTO(String accessToken, String refreshToken, Boolean needInitialization) {
+
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/dto/SocialSignDTO.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/dto/SocialSignDTO.java
@@ -1,5 +1,7 @@
 package com.walkingtalking.gunilda.user.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.walkingtalking.gunilda.user.type.SocialType;
 import lombok.Builder;
 
@@ -21,7 +23,8 @@ public class SocialSignDTO {
     }
 
     @Builder
-    public record SignInResponse(Long userId) {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record SignInResponse(Long userId, Boolean needInitialization) {
 
     }
 }

--- a/src/main/java/com/walkingtalking/gunilda/user/service/UserProfileService.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/UserProfileService.java
@@ -7,5 +7,5 @@ public interface UserProfileService {
     UserProfileDTO.ChangeProfileResponse changeProfile(UserProfileDTO.ChangeProfileCommand profileCommand);
     UserProfileDTO.ChangeNicknameResponse changeNickname(UserProfileDTO.ChangeNicknameCommand nicknameCommand);
     UserProfileDTO.CreateProfileResponse createProfile(UserProfileDTO.CreateProfileCommand profileCommand);
-    Boolean needChangingProfile(Long userId);
+    Boolean needInitializeProfile(Long userId);
 }

--- a/src/main/java/com/walkingtalking/gunilda/user/service/UserProfileService.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/UserProfileService.java
@@ -6,6 +6,6 @@ public interface UserProfileService {
 
     UserProfileDTO.ChangeProfileResponse changeProfile(UserProfileDTO.ChangeProfileCommand profileCommand);
     UserProfileDTO.ChangeNicknameResponse changeNickname(UserProfileDTO.ChangeNicknameCommand nicknameCommand);
-
     UserProfileDTO.CreateProfileResponse createProfile(UserProfileDTO.CreateProfileCommand profileCommand);
+    Boolean needChangingProfile(Long userId);
 }

--- a/src/main/java/com/walkingtalking/gunilda/user/service/impl/SocialSignServiceImpl.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/impl/SocialSignServiceImpl.java
@@ -43,7 +43,7 @@ public class SocialSignServiceImpl implements SocialSignService {
 
         return SocialSignDTO.SignInResponse.builder()
                 .userId(social.getUserId())
-                .needInitialization(userProfileService.needChangingProfile(social.getUserId()))
+                .needInitialization(userProfileService.needInitializeProfile(social.getUserId()))
                 .build();
     }
 

--- a/src/main/java/com/walkingtalking/gunilda/user/service/impl/SocialSignServiceImpl.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/impl/SocialSignServiceImpl.java
@@ -5,6 +5,7 @@ import com.walkingtalking.gunilda.user.dto.UserSignDTO;
 import com.walkingtalking.gunilda.user.entity.Social;
 import com.walkingtalking.gunilda.user.repository.SocialRepository;
 import com.walkingtalking.gunilda.user.service.SocialSignService;
+import com.walkingtalking.gunilda.user.service.UserProfileService;
 import com.walkingtalking.gunilda.user.service.UserSignService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,7 @@ public class SocialSignServiceImpl implements SocialSignService {
 
     private final SocialRepository socialRepository;
     private final UserSignService userSignService;
+    private final UserProfileService userProfileService;
 
     @Override
     @Transactional
@@ -41,6 +43,7 @@ public class SocialSignServiceImpl implements SocialSignService {
 
         return SocialSignDTO.SignInResponse.builder()
                 .userId(social.getUserId())
+                .needInitialization(userProfileService.needChangingProfile(social.getUserId()))
                 .build();
     }
 

--- a/src/main/java/com/walkingtalking/gunilda/user/service/impl/UserProfileServiceImpl.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/impl/UserProfileServiceImpl.java
@@ -74,7 +74,7 @@ public class UserProfileServiceImpl implements UserProfileService {
 
     @Override
     @Transactional
-    public Boolean needChangingProfile(Long userId) {
+    public Boolean needInitializeProfile(Long userId) {
         User user = profileRepository.findByUserId(userId)
                 .orElseThrow(() -> new ProfileException(ProfileExceptionType.USER_NOT_FOUND));
 

--- a/src/main/java/com/walkingtalking/gunilda/user/service/impl/UserProfileServiceImpl.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/service/impl/UserProfileServiceImpl.java
@@ -72,5 +72,13 @@ public class UserProfileServiceImpl implements UserProfileService {
         return UserProfileDTO.CreateProfileResponse.from(profileResponse, nicknameResponse);
     }
 
+    @Override
+    @Transactional
+    public Boolean needChangingProfile(Long userId) {
+        User user = profileRepository.findByUserId(userId)
+                .orElseThrow(() -> new ProfileException(ProfileExceptionType.USER_NOT_FOUND));
+
+        return user.getGender() == GenderType.UNKNOWN;
+    }
 
 }


### PR DESCRIPTION
### 변경점
- UserProfile을 담당하는 service에 프로필 초기화 필요 여부를 판단하는 기능 추가
- 소셜 로그인 시 프로필 초기화 필요 여부를 추가로 담아 응답하도록 수정
- 로그인 최종 응답에 프로필 초기화 필요 여부가 담기도록 수정