### PR TITLE
feat: 사용자의 stride, speed, step 데이터를 기간별로 조회하는 기능 추가

### DIFF
--- a/src/main/java/com/walkingtalking/gunilda/exercise/controller/ExerciseAnalyzeController.java
+++ b/src/main/java/com/walkingtalking/gunilda/exercise/controller/ExerciseAnalyzeController.java
@@ -1,0 +1,39 @@
+package com.walkingtalking.gunilda.exercise.controller;
+
+import com.walkingtalking.gunilda.exercise.dto.AnalyzeExerciseDTO;
+import com.walkingtalking.gunilda.exercise.service.ExerciseAnalyzeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/exercise/stats")
+@Slf4j
+public class ExerciseAnalyzeController {
+
+    private final ExerciseAnalyzeService analyzeService;
+
+    @GetMapping("/stride")
+    public ResponseEntity<AnalyzeExerciseDTO.StrideResponse> getStrideData(@RequestAttribute Long userId,
+                                                                           @ModelAttribute AnalyzeExerciseDTO.StrideRequest request) {
+
+        return ResponseEntity.ok(analyzeService.getStrideData(request.toCommand(userId)));
+    }
+
+    @GetMapping("/speed")
+    public ResponseEntity<AnalyzeExerciseDTO.SpeedResponse> getSpeedData(@RequestAttribute Long userId,
+                                                                         @ModelAttribute AnalyzeExerciseDTO.SpeedRequest request) {
+
+        return ResponseEntity.ok(analyzeService.getSpeedData(request.toCommand(userId)));
+    }
+
+    @GetMapping("/step")
+    public ResponseEntity<AnalyzeExerciseDTO.StepResponse> getStepData(@RequestAttribute Long userId,
+                                                                       @ModelAttribute AnalyzeExerciseDTO.StepRequest request) {
+
+        return ResponseEntity.ok(analyzeService.getStepData(request.toCommand(userId)));
+    }
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/exercise/dto/AnalyzeExerciseDTO.java
+++ b/src/main/java/com/walkingtalking/gunilda/exercise/dto/AnalyzeExerciseDTO.java
@@ -1,0 +1,111 @@
+package com.walkingtalking.gunilda.exercise.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.walkingtalking.gunilda.exercise.type.DateType;
+import lombok.Builder;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+
+public class AnalyzeExerciseDTO {
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record StrideRequest(String type, String startDate, String endDate) {
+
+        public StrideCommand toCommand(Long userId) {
+            return StrideCommand.builder()
+                    .userId(userId)
+                    .dateType(DateType.find(type))
+                    .startDate(Timestamp.from(Instant.parse(startDate)))
+                    .endDate(Timestamp.from(Instant.parse(endDate)))
+                    .build();
+        }
+    }
+
+    @Builder
+    public record StrideCommand(Long userId, DateType dateType, Timestamp startDate, Timestamp endDate) {
+
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record StrideResponse(List<Stride> mine, List<Stride> ageGroup) {
+
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record Stride(Integer minStride, Integer maxStride, Integer averageStride,
+                         @JsonFormat(pattern = "yyyy-MM-dd'T'HH-mm-ssXXX", timezone = "Asia/Seoul") Timestamp date) {
+    }
+
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record SpeedRequest(String type, String startDate, String endDate) {
+
+        public SpeedCommand toCommand(Long userId) {
+            return SpeedCommand.builder()
+                    .userId(userId)
+                    .dateType(DateType.find(type))
+                    .startDate(Timestamp.from(Instant.parse(startDate)))
+                    .endDate(Timestamp.from(Instant.parse(endDate)))
+                    .build();
+        }
+    }
+
+    @Builder
+    public record SpeedCommand(Long userId, DateType dateType, Timestamp startDate, Timestamp endDate) {
+
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record SpeedResponse(List<Speed> mine, List<Speed> ageGroup) {
+
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record Speed(Double minSpeed, Double maxSpeed, Double averageSpeed,
+                         @JsonFormat(pattern = "yyyy-MM-dd'T'HH-mm-ssXXX", timezone = "Asia/Seoul") Timestamp date) {
+    }
+
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record StepRequest(String type, String startDate, String endDate) {
+
+        public StepCommand toCommand(Long userId) {
+            return StepCommand.builder()
+                    .userId(userId)
+                    .dateType(DateType.find(type))
+                    .startDate(Timestamp.from(Instant.parse(startDate)))
+                    .endDate(Timestamp.from(Instant.parse(endDate)))
+                    .build();
+        }
+    }
+
+    @Builder
+    public record StepCommand(Long userId, DateType dateType, Timestamp startDate, Timestamp endDate) {
+
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record StepResponse(List<Step> mine, List<Step> ageGroup) {
+
+    }
+
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record Step(Integer step,
+                       @JsonFormat(pattern = "yyyy-MM-dd'T'HH-mm-ssXXX", timezone = "Asia/Seoul") Timestamp date) {
+
+    }
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/exercise/entity/Exercise.java
+++ b/src/main/java/com/walkingtalking/gunilda/exercise/entity/Exercise.java
@@ -46,7 +46,7 @@ public class Exercise {
     @Column(nullable = false)
     private Double averageSpeed;
 
-    @Transient
+    @Column(nullable = false)
     private Integer dataCount;
 
 

--- a/src/main/java/com/walkingtalking/gunilda/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/com/walkingtalking/gunilda/exercise/repository/ExerciseRepository.java
@@ -4,6 +4,7 @@ import com.walkingtalking.gunilda.exercise.entity.Exercise;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,5 +15,8 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
     List<Exercise> findAllByUserId(Long userId);
 
     List<Exercise> findAllByIdIsIn(List<Long> ids);
+
+    List<Exercise> findAllByUserIdAndEndTimeIsBetween(Long userId, Timestamp startDate, Timestamp endDate);
+    List<Exercise> findAllByUserIdIsInAndEndTimeIsBetween(List<Long> userIds, Timestamp startDate, Timestamp endDate);
 
 }

--- a/src/main/java/com/walkingtalking/gunilda/exercise/service/ExerciseAnalyzeService.java
+++ b/src/main/java/com/walkingtalking/gunilda/exercise/service/ExerciseAnalyzeService.java
@@ -1,0 +1,11 @@
+package com.walkingtalking.gunilda.exercise.service;
+
+import com.walkingtalking.gunilda.exercise.dto.AnalyzeExerciseDTO;
+
+public interface ExerciseAnalyzeService {
+
+    AnalyzeExerciseDTO.StrideResponse getStrideData(AnalyzeExerciseDTO.StrideCommand command);
+    AnalyzeExerciseDTO.SpeedResponse getSpeedData(AnalyzeExerciseDTO.SpeedCommand command);
+    AnalyzeExerciseDTO.StepResponse getStepData(AnalyzeExerciseDTO.StepCommand command);
+
+}

--- a/src/main/java/com/walkingtalking/gunilda/exercise/service/impl/ExerciseAnalyzeServiceImpl.java
+++ b/src/main/java/com/walkingtalking/gunilda/exercise/service/impl/ExerciseAnalyzeServiceImpl.java
@@ -1,0 +1,236 @@
+package com.walkingtalking.gunilda.exercise.service.impl;
+
+import com.walkingtalking.gunilda.exercise.dto.AnalyzeExerciseDTO;
+import com.walkingtalking.gunilda.exercise.entity.Exercise;
+import com.walkingtalking.gunilda.exercise.repository.ExerciseRepository;
+import com.walkingtalking.gunilda.exercise.service.ExerciseAnalyzeService;
+import com.walkingtalking.gunilda.exercise.type.DateType;
+import com.walkingtalking.gunilda.user.repository.UserRepository;
+import com.walkingtalking.gunilda.user.type.AgeType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExerciseAnalyzeServiceImpl implements ExerciseAnalyzeService {
+
+    private final UserRepository userRepository;
+    private final ExerciseRepository exerciseRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AnalyzeExerciseDTO.StrideResponse getStrideData(AnalyzeExerciseDTO.StrideCommand command) {
+        if (command.dateType() == DateType.UNKNOWN) {
+            return AnalyzeExerciseDTO.StrideResponse.builder()
+                    .mine(Collections.emptyList())
+                    .ageGroup(Collections.emptyList())
+                    .build();
+        }
+
+        AgeType userAge = userRepository.findAgeByUserId(command.userId());
+        List<Long> ageGroup = userRepository.findAllUserIdByAge(userAge);
+
+        List<Exercise> myExercises = exerciseRepository.findAllByUserIdAndEndTimeIsBetween(command.userId(), command.startDate(), command.endDate());
+
+        if (command.dateType() == DateType.HOUR) {
+            return AnalyzeExerciseDTO.StrideResponse.builder()
+                    .mine(getStrideData(collectByDateType(command.dateType(), myExercises, command.startDate(), command.endDate())))
+                    .ageGroup(Collections.emptyList())
+                    .build();
+        }
+
+        List<Exercise> groupExercises = exerciseRepository.findAllByUserIdIsInAndEndTimeIsBetween(ageGroup, command.startDate(), command.endDate());
+
+        return AnalyzeExerciseDTO.StrideResponse.builder()
+                .mine(getStrideData(collectByDateType(command.dateType(), myExercises, command.startDate(), command.endDate())))
+                .ageGroup(getStrideData(collectByDateType(command.dateType(), groupExercises, command.startDate(), command.endDate())))
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AnalyzeExerciseDTO.SpeedResponse getSpeedData(AnalyzeExerciseDTO.SpeedCommand command) {
+        if (command.dateType() == DateType.UNKNOWN) {
+            return AnalyzeExerciseDTO.SpeedResponse.builder()
+                    .mine(Collections.emptyList())
+                    .ageGroup(Collections.emptyList())
+                    .build();
+        }
+
+        AgeType userAge = userRepository.findAgeByUserId(command.userId());
+        List<Long> ageGroup = userRepository.findAllUserIdByAge(userAge);
+
+        List<Exercise> myExercises = exerciseRepository.findAllByUserIdAndEndTimeIsBetween(command.userId(), command.startDate(), command.endDate());
+
+        if (command.dateType() == DateType.HOUR) {
+            return AnalyzeExerciseDTO.SpeedResponse.builder()
+                    .mine(getSpeedData(collectByDateType(command.dateType(), myExercises, command.startDate(), command.endDate())))
+                    .ageGroup(Collections.emptyList())
+                    .build();
+        }
+
+        List<Exercise> groupExercises = exerciseRepository.findAllByUserIdIsInAndEndTimeIsBetween(ageGroup, command.startDate(), command.endDate());
+
+        return AnalyzeExerciseDTO.SpeedResponse.builder()
+                .mine(getSpeedData(collectByDateType(command.dateType(), myExercises, command.startDate(), command.endDate())))
+                .ageGroup(getSpeedData(collectByDateType(command.dateType(), groupExercises, command.startDate(), command.endDate())))
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AnalyzeExerciseDTO.StepResponse getStepData(AnalyzeExerciseDTO.StepCommand command) {
+        if (command.dateType() == DateType.UNKNOWN) {
+            return AnalyzeExerciseDTO.StepResponse.builder()
+                    .mine(Collections.emptyList())
+                    .ageGroup(Collections.emptyList())
+                    .build();
+        }
+
+        AgeType userAge = userRepository.findAgeByUserId(command.userId());
+        List<Long> ageGroup = userRepository.findAllUserIdByAge(userAge);
+
+        List<Exercise> myExercises = exerciseRepository.findAllByUserIdAndEndTimeIsBetween(command.userId(), command.startDate(), command.endDate());
+
+        if (command.dateType() == DateType.HOUR) {
+            return AnalyzeExerciseDTO.StepResponse.builder()
+                    .mine(getStepData(collectByDateType(command.dateType(), myExercises, command.startDate(), command.endDate())))
+                    .ageGroup(Collections.emptyList())
+                    .build();
+        }
+
+        List<Exercise> groupExercises = exerciseRepository.findAllByUserIdIsInAndEndTimeIsBetween(ageGroup, command.startDate(), command.endDate());
+
+        return AnalyzeExerciseDTO.StepResponse.builder()
+                .mine(getStepData(collectByDateType(command.dateType(), myExercises, command.startDate(), command.endDate())))
+                .ageGroup(getStepData(collectByDateType(command.dateType(), groupExercises, command.startDate(), command.endDate())))
+                .build();
+    }
+
+    private Map<LocalDateTime, List<Exercise>> collectByDateType(DateType dateType, List<Exercise> exercises, Timestamp startDate, Timestamp endDate) {
+        Map<LocalDateTime, List<Exercise>> exerciseCollection = new HashMap<>();
+
+        LocalDateTime start = truncate(startDate.toLocalDateTime(), dateType);
+        LocalDateTime end = truncate(endDate.toLocalDateTime(), dateType).plus(1, dateType.getUnit());
+        for (LocalDateTime key = start; !key.isEqual(end); key = key.plus(1, dateType.getUnit())) {
+            exerciseCollection.put(key, new ArrayList<>());
+        }
+
+        exercises.forEach(exercise -> {
+            LocalDateTime key = truncate(exercise.getEndTime().toLocalDateTime(), dateType);
+            List<Exercise> collectedExercises = exerciseCollection.get(key);
+
+            collectedExercises.add(exercise);
+        });
+
+        return exerciseCollection;
+    }
+
+    private LocalDateTime truncate(LocalDateTime localDateTime, DateType dateType) {
+        return switch (dateType) {
+            case HOUR, DAY -> localDateTime.truncatedTo(dateType.getUnit());
+            case WEEK -> localDateTime.minusDays(localDateTime.getDayOfWeek().getValue()-1).truncatedTo(ChronoUnit.DAYS);
+            case MONTH -> localDateTime.with(TemporalAdjusters.firstDayOfMonth()).truncatedTo(ChronoUnit.DAYS);
+            case UNKNOWN -> null;
+        };
+    }
+
+    private List<AnalyzeExerciseDTO.Stride> getStrideData(Map<LocalDateTime, List<Exercise>> exerciseCollection) {
+        return exerciseCollection.entrySet().stream()
+                .map(entry -> {
+                    AtomicReference<Integer> minStride = new AtomicReference<>(Integer.MAX_VALUE);
+                    AtomicReference<Integer> maxStride = new AtomicReference<>(0);
+                    AtomicReference<Integer> averageStride = new AtomicReference<>(0);
+                    AtomicReference<Integer> dataCount = new AtomicReference<>(0);
+
+                    entry.getValue().forEach(exercise -> {
+                        minStride.set(Math.min(minStride.get(), exercise.getMinStride()));
+                        maxStride.set(Math.max(maxStride.get(), exercise.getMaxStride()));
+                        averageStride.updateAndGet(v -> v + exercise.getAverageStride() * exercise.getDataCount());
+                        dataCount.updateAndGet(v -> v + exercise.getDataCount());
+                    });
+
+                    if (minStride.get() == Integer.MAX_VALUE) {
+                        minStride.set(0);
+                    }
+                    dataCount.compareAndSet(0, 1);
+
+                    return AnalyzeExerciseDTO.Stride.builder()
+                            .minStride(minStride.get())
+                            .maxStride(maxStride.get())
+                            .averageStride(averageStride.get() / dataCount.get())
+                            .date(Timestamp.valueOf(entry.getKey()))
+                            .build();
+                })
+                .sorted(Comparator.comparing(AnalyzeExerciseDTO.Stride::date))
+                .collect(Collectors.toList());
+    }
+
+
+    private List<AnalyzeExerciseDTO.Speed> getSpeedData(Map<LocalDateTime, List<Exercise>> exerciseCollection) {
+        return exerciseCollection.entrySet().stream()
+                .map(entry -> {
+                    AtomicReference<Double> minSpeed = new AtomicReference<>(Double.MAX_VALUE);
+                    AtomicReference<Double> maxSpeed = new AtomicReference<>(0.0);
+                    AtomicReference<Double> averageSpeed = new AtomicReference<>(0.0);
+                    AtomicReference<Integer> dataCount = new AtomicReference<>(0);
+
+                    entry.getValue().forEach(exercise -> {
+                        minSpeed.set(Math.min(minSpeed.get(), exercise.getMinSpeed()));
+                        maxSpeed.set(Math.max(maxSpeed.get(), exercise.getMaxSpeed()));
+                        averageSpeed.updateAndGet(v -> v + exercise.getAverageSpeed() * exercise.getDataCount());
+                        dataCount.updateAndGet(v -> v + exercise.getDataCount());
+                    });
+
+                    if (minSpeed.get() == Double.MAX_VALUE) {
+                        minSpeed.set(0.0);
+                    }
+                    dataCount.compareAndSet(0, 1);
+
+                    Double minSpeedFloor = Math.floor(minSpeed.get() * 10) / 10;
+                    Double maxSpeedFloor = Math.floor(maxSpeed.get() * 10) / 10;
+                    Double averageSpeedFloor = Math.floor((averageSpeed.get() / dataCount.get()) * 10) / 10;
+
+                    return AnalyzeExerciseDTO.Speed.builder()
+                            .minSpeed(minSpeedFloor)
+                            .maxSpeed(maxSpeedFloor)
+                            .averageSpeed(averageSpeedFloor)
+                            .date(Timestamp.valueOf(entry.getKey()))
+                            .build();
+                })
+                .sorted(Comparator.comparing(AnalyzeExerciseDTO.Speed::date))
+                .collect(Collectors.toList());
+    }
+
+
+    private List<AnalyzeExerciseDTO.Step> getStepData(Map<LocalDateTime, List<Exercise>> exerciseCollection) {
+        return exerciseCollection.entrySet().stream()
+                .map(entry -> {
+                    AtomicReference<Integer> step = new AtomicReference<>(0);
+                    Set<Long> users = new HashSet<>();
+
+                    entry.getValue().forEach(exercise -> {
+                        step.updateAndGet(v -> v + exercise.getStep());
+                        users.add(exercise.getUserId());
+                    });
+
+                    return AnalyzeExerciseDTO.Step.builder()
+                            .step(step.get() / users.size())
+                            .date(Timestamp.valueOf(entry.getKey()))
+                            .build();
+                })
+                .sorted(Comparator.comparing(AnalyzeExerciseDTO.Step::date))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/walkingtalking/gunilda/exercise/type/DateType.java
+++ b/src/main/java/com/walkingtalking/gunilda/exercise/type/DateType.java
@@ -1,0 +1,38 @@
+package com.walkingtalking.gunilda.exercise.type;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Getter
+@AllArgsConstructor
+public enum DateType {
+    UNKNOWN("unknown", null),
+    HOUR("hour", ChronoUnit.HOURS),
+    DAY("day", ChronoUnit.DAYS),
+    WEEK("week", ChronoUnit.WEEKS),
+    MONTH("month", ChronoUnit.MONTHS);
+
+    @JsonValue
+    private final String date;
+    private final TemporalUnit unit;
+
+    private static final Map<String, DateType> dates =
+            Collections.unmodifiableMap(
+                    Stream.of(DateType.values())
+                            .collect(Collectors.toMap(DateType::getDate, Function.identity()))
+            );
+
+    public static DateType find(String date) {
+        return Optional.ofNullable(dates.get(date)).orElse(UNKNOWN);
+    }
+}

--- a/src/main/java/com/walkingtalking/gunilda/user/repository/UserRepository.java
+++ b/src/main/java/com/walkingtalking/gunilda/user/repository/UserRepository.java
@@ -5,6 +5,7 @@ import com.walkingtalking.gunilda.user.type.AgeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -14,5 +15,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u.age FROM User u WHERE u.userId = :userId")
     AgeType findAgeByUserId(Long userId);
+
+    @Query("SELECT u.userId FROM User u WHERE u.age = :age")
+    List<Long> findAllUserIdByAge(AgeType age);
 
 }


### PR DESCRIPTION
## 구현 목록
- 정렬 기준 (hour, day, week, month)에 따라 사용자의 stride, speed, step 정보를 통계로 바꿔주는 기능 추가
- hour이 아닌 경우 사용자의 연령대의 운동 평균을 같이 보내주는 기능 추가
- stride는 min, max, average와 통계로 묶인 날짜를 보내줌
ex) 6월 1일 00:00 ~ 23:59 => 6월 1일 00:00 으로 묶임
- speed는 min, max, average와 통계로 묶인 날짜를 보내줌
- step은 step과 통계로 묶인 날짜를 보내줌
- 데이터의 개수는 startDate와 endDate 사이에서 정렬 기준에 따라 나눌 수 있는 날짜들의 개수와 동일함
ex) startDate = 6월 1일 00시, endDate = 6월 1일 23시, 정렬 기준 = hour일 때 데이터의 개수는 24개 (00시 ~ 23시)